### PR TITLE
Explain why one key format is not realistic.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1173,12 +1173,23 @@ the Data Integrity EdDSA Cryptosuites</a>.
             </p>
 
             <p>
+Implementers are often exposed to many different verification material formats
+such as
+<a href="https://en.wikipedia.org/wiki/Secure_Shell">SSH public keys</a>,
+<a href="https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail">
+PEM-encoded public keys</a>,
+hex-encoded public keys,
+<a data-cite="?RFC7517">JSON Web Keys</a>,
+<a href="#Multikey">Multikeys</a>, and
+<a data-cite="?8152#section-7">COSE public keys</a>.
 To increase the likelihood of interoperable implementations, this specification
-limits the number of formats for expressing verification material in a
-[=controller document=]. The fewer formats that implementers have to
-choose from, the more likely that interoperability will be achieved. This
-approach attempts to strike a delicate balance between easing implementation
-and providing support for formats that have historically had broad deployment.
+suggests limiting the number of formats used to express verification material in
+a [=controller document=]. The fewer formats that implementers have to choose
+from, the more likely that interoperability will be achieved for a particular
+ecosystem. Ideally, there would be one public key format, however, history has
+demonstrated that not to be the case and acknowledges that implementers will
+support as many verification material formats as makes sense for their
+ecosystem.
             </p>
 
             <p>

--- a/index.html
+++ b/index.html
@@ -1186,10 +1186,11 @@ To increase the likelihood of interoperable implementations, this specification
 suggests limiting the number of formats used to express verification material in
 a [=controller document=]. The fewer formats that implementers have to choose
 from, the more likely that interoperability will be achieved for a particular
-ecosystem. Ideally, there would be one public key format, however, history has
-demonstrated that not to be the case and acknowledges that implementers will
-support as many verification material formats as makes sense for their
-ecosystem.
+ecosystem. Ideally, there would be one verification material format per
+application; however, history has shown both that multiple verification
+material formats might be used with any given application, and that
+implementers will support as many verification material formats as make
+sense for their ecosystem.
             </p>
 
             <p>


### PR DESCRIPTION
This PR attempts to address issue #115 by explaining that having one key format is not realistic, how the spec attempts to minimize key formats, but understands that ecosystems have to support the key formats that are native to their ecosystems.

/cc @peacekeeper


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/120.html" title="Last updated on Nov 18, 2024, 4:28 PM UTC (f7e4d54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/120/f2baa07...f7e4d54.html" title="Last updated on Nov 18, 2024, 4:28 PM UTC (f7e4d54)">Diff</a>