### PR TITLE
Add IANA Considerations section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3670,6 +3670,61 @@ calculation.
 
     </section>
 
+    </section>
+
+    <section class="appendix informative">
+      <h2>IANA Considerations</h2>
+
+      <p>
+This section will be submitted to the Internet Engineering Steering Group
+(IESG) for review, approval, and registration with IANA.
+      </p>
+
+      <section id="controller-media-type">
+        <h2>application/controller</h2>
+        <p>
+This specification registers the `application/controller` media type
+specifically for identifying documents conforming to the [=controller document=]
+format.
+        </p>
+        <table>
+          <tr>
+            <td>Type name: </td>
+            <td>application</td>
+          </tr>
+          <tr>
+            <td>Subtype name: </td>
+            <td>controller</td>
+          </tr>
+          <tr>
+            <td>Required parameters: </td>
+            <td>None</td>
+          </tr>
+          <tr>
+            <td>Encoding considerations: </td>
+            <td>
+Resources that use the `application/controller` media type are required to
+conform to all of the requirements for the `application/json` media type and are
+therefore subject to the same encoding considerations specified in Section 11 of
+[[[RFC7159]]].
+            </td>
+          </tr>
+          <tr>
+            <td>Security considerations: </td>
+            <td>As defined in the [[[CONTROLLER-DOCUMENT]]].</td>
+          </tr>
+          <tr>
+            <td>Contact: </td>
+            <td>
+W3C Verifiable Credentials Working Group
+<a href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+            </td>
+          </tr>
+        </table>
+
+      </section>
+    </section>
+
     <section class="appendix informative">
       <h2>Examples</h2>
 

--- a/index.html
+++ b/index.html
@@ -3681,10 +3681,10 @@ This section will be submitted to the Internet Engineering Steering Group
       </p>
 
       <section id="controller-media-type">
-        <h2>application/controller</h2>
+        <h2>application/cid</h2>
         <p>
-This specification registers the `application/controller` media type
-specifically for identifying documents conforming to the [=controller document=]
+This specification registers the `application/cid` media type specifically for
+identifying documents conforming to the [=controllable identifier document=]
 format.
         </p>
         <table>
@@ -3703,9 +3703,9 @@ format.
           <tr>
             <td>Encoding considerations: </td>
             <td>
-Resources that use the `application/controller` media type are required to
-conform to all of the requirements for the `application/json` media type and are
-therefore subject to the same encoding considerations specified in Section 11 of
+Resources that use the `application/cid` media type are required to conform to
+all of the requirements for the `application/json` media type and are therefore
+subject to the same encoding considerations specified in Section 11 of
 [[[RFC7159]]].
             </td>
           </tr>


### PR DESCRIPTION
This PR is an attempt to address issue #127 by adding an IANA Considerations section to register the media type for controller documents.

I have marked this PR "DO NOT MERGE" until we have a resolution for the title of the specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/cid/pull/129.html" title="Last updated on Dec 8, 2024, 4:49 PM UTC (6f96976)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cid/129/824157e...6f96976.html" title="Last updated on Dec 8, 2024, 4:49 PM UTC (6f96976)">Diff</a>