### PR TITLE
Add SM2 Algorithm Support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1435,6 +1435,16 @@ then be encoded using the base-58-btc alphabet, according to Section
 (`z`).
                   </td>
                 </tr>
+                <tr>
+                  <td>SM2 256-bit public key</td>
+                  <td>
+The encoding of a SM2 public key MUST start with the two-byte prefix
+`0x8624` (the varint expression of `0x1206`) followed by the 33-byte compressed
+public key data. The resulting 35-byte value MUST then be encoded using the
+base-58-btc alphabet, according to Section [[[#multibase-0]]], and then
+prepended with the base-58-btc Multibase header (`z`).
+                  </td>
+                </tr>
               </tbody>
             </table>
 
@@ -1487,6 +1497,16 @@ by the 96-byte compressed public key data. The resulting 98-byte value MUST
 then be encoded using the base-58-btc alphabet, according to Section
 [[[#multibase-0]]], and then prepended with the base-58-btc Multibase header
 (`z`).
+                  </td>
+                </tr>
+                <tr>
+                  <td>SM2 256-bit secret key</td>
+                  <td>
+The encoding of a SM2 secret key MUST start with the two-byte prefix
+`0x9026` (the varint expression of `0x1310`) followed by the 32-byte
+secret key data. The resulting 34-byte value MUST then be encoded using the
+base-58-btc alphabet, according to Section [[[#multibase-0]]], and then
+prepended with the base-58-btc Multibase header (`z`).
                   </td>
                 </tr>
               </tbody>
@@ -3766,6 +3786,16 @@ developers seeking test values.
   ]
 }
           </pre>
+
+          <pre class="example nohighlight"
+            title="A SM2 public key encoded as a Multikey">
+{
+  "id": "https://multikey.example/issuer/123#key-0",
+  "type": "Multikey",
+  "controller": "https://multikey.example/issuer/123",
+  "publicKeyMultibase": "zEPJc1vCfbG2aoZn8f3U8ggYRL4ZFfF63ZA3qFSk81WJxnCQr"
+}
+          </pre>
         </section>
         <section class="informative">
         <h2>JsonWebKey Examples</h2>
@@ -3882,6 +3912,21 @@ developers seeking test values.
   "capabilityInvocation": [
     "https://controller.example/123#key-2"
   ]
+}
+          </pre>
+
+          <pre class="example nohighlight"
+            title="A SM2 public key encoded as a JsonWebKey">
+{
+  "id": "https://jsonwebkey.example/issuer/123#key-0",
+  "type": "JsonWebKey",
+  "controller": "https://jsonwebkey.example/issuer/123",
+  "publicKeyJwk": {
+    "kty": "EC",
+    "crv": "SM2",
+    "x": "NIMpjy0M25izi2DrQLhQBlL8b45Lt9a0FzfELdpdO0s",
+    "y": "NXstrSPtSp1cZzvupZ8C68FCgSQhZbuGYLorP6F1N2w"
+  }
 }
           </pre>
         </section>

--- a/index.html
+++ b/index.html
@@ -1438,7 +1438,7 @@ then be encoded using the base-58-btc alphabet, according to Section
                 <tr>
                   <td>SM2 256-bit public key</td>
                   <td>
-The encoding of a SM2 public key MUST start with the two-byte prefix
+The encoding of an SM2 public key MUST start with the two-byte prefix
 `0x8624` (the varint expression of `0x1206`) followed by the 33-byte compressed
 public key data. The resulting 35-byte value MUST then be encoded using the
 base-58-btc alphabet, according to Section [[[#multibase-0]]], and then
@@ -1502,7 +1502,7 @@ then be encoded using the base-58-btc alphabet, according to Section
                 <tr>
                   <td>SM2 256-bit secret key</td>
                   <td>
-The encoding of a SM2 secret key MUST start with the two-byte prefix
+The encoding of an SM2 secret key MUST start with the two-byte prefix
 `0x9026` (the varint expression of `0x1310`) followed by the 32-byte
 secret key data. The resulting 34-byte value MUST then be encoded using the
 base-58-btc alphabet, according to Section [[[#multibase-0]]], and then

--- a/index.html
+++ b/index.html
@@ -3914,21 +3914,6 @@ developers seeking test values.
   ]
 }
           </pre>
-
-          <pre class="example nohighlight"
-            title="An SM2 public key encoded as a JsonWebKey">
-{
-  "id": "https://jsonwebkey.example/issuer/123#key-0",
-  "type": "JsonWebKey",
-  "controller": "https://jsonwebkey.example/issuer/123",
-  "publicKeyJwk": {
-    "kty": "EC",
-    "crv": "SM2",
-    "x": "NIMpjy0M25izi2DrQLhQBlL8b45Lt9a0FzfELdpdO0s",
-    "y": "NXstrSPtSp1cZzvupZ8C68FCgSQhZbuGYLorP6F1N2w"
-  }
-}
-          </pre>
         </section>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -3788,7 +3788,7 @@ developers seeking test values.
           </pre>
 
           <pre class="example nohighlight"
-            title="A SM2 public key encoded as a Multikey">
+            title="An SM2 public key encoded as a Multikey">
 {
   "id": "https://multikey.example/issuer/123#key-0",
   "type": "Multikey",
@@ -3916,7 +3916,7 @@ developers seeking test values.
           </pre>
 
           <pre class="example nohighlight"
-            title="A SM2 public key encoded as a JsonWebKey">
+            title="An SM2 public key encoded as a JsonWebKey">
 {
   "id": "https://jsonwebkey.example/issuer/123#key-0",
   "type": "JsonWebKey",


### PR DESCRIPTION
## Overview
Add SM2 (ShangMi 2) cryptographic algorithm support to the controller document specification. SM2 is a public key cryptographic algorithm based on elliptic curves, which has been standardized as GM/T 0003-2012 by the State Cryptography Administration of China.

## Changes
- Added SM2 algorithm specification and parameters
- Included SM2 in the supported cryptographic algorithms list
- Added relevant documentation and examples

## Motivation
SM2 is widely used in China's commercial cryptographic applications and has been proven to provide strong security. Adding SM2 support enhances the specification's compatibility with Chinese cryptographic standards and provides more options for implementers requiring compliance with Chinese regulations.

## Impact
This addition expands the cryptographic algorithm options available to implementers while maintaining backward compatibility with existing implementations.

## Related Issues
N/A


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xicilion/controller-document/pull/131.html" title="Last updated on Dec 18, 2024, 4:59 PM UTC (2bd3269)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cid/131/9b500df...xicilion:2bd3269.html" title="Last updated on Dec 18, 2024, 4:59 PM UTC (2bd3269)">Diff</a>