### PR TITLE
Remove the numerical error codes to be in sync with the VCDM specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -2687,8 +2687,8 @@ relationships exist as described earlier in this section.
         <p>
 The algorithms described in this specification throw specific types of errors.
 Implementers might find it useful to convey these errors to other libraries or
-software systems. This section provides specific URLs, descriptions, and error
-codes for the errors, such that an ecosystem implementing technologies described
+software systems. This section provides specific URLs and descriptions for the errors,
+such that an ecosystem implementing technologies described
 by this specification might interoperate more effectively when errors occur.
         </p>
 
@@ -2704,40 +2704,36 @@ The `type` value of the error object MUST be a URL that starts with the value
 below.
           </li>
           <li>
-The `code` value MUST be the integer code described in the table below
-(in parentheses, beside the type name).
-          </li>
-          <li>
-The `title` value SHOULD provide a short but specific human-readable string for
+The `title` value MUST be present and it SHOULD provide a short but specific human-readable string for
 the error.
           </li>
           <li>
-The `detail` value SHOULD provide a longer human-readable string for the error.
+The `detail` value  MUST be present and it SHOULD provide a longer human-readable string for the error.
           </li>
         </ul>
 
         <dl>
-          <dt id="INVALID_VERIFICATION_METHOD_URL">INVALID_VERIFICATION_METHOD_URL (-21)</dt>
+          <dt id="INVALID_VERIFICATION_METHOD_URL">INVALID_VERIFICATION_METHOD_URL</dt>
           <dd>
 The `verificationMethod` value in a [=proof=] was malformed. See Section
 [[[#retrieve-verification-method]]].
           </dd>
-          <dt id="INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID">INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID (-22)</dt>
+          <dt id="INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID">INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID</dt>
           <dd>
 The `id` value in a [=controlled identifier document=] was malformed. See Section
 [[[#retrieve-verification-method]]].
           </dd>
-          <dt id="INVALID_CONTROLLED_IDENTIFIER_DOCUMENT">INVALID_CONTROLLED_IDENTIFIER_DOCUMENT (-23)</dt>
+          <dt id="INVALID_CONTROLLED_IDENTIFIER_DOCUMENT">INVALID_CONTROLLED_IDENTIFIER_DOCUMENT</dt>
           <dd>
 The [=controlled identifier document=] was malformed. See Section
 [[[#retrieve-verification-method]]].
           </dd>
-          <dt id="INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD (-24)</dt>
+          <dt id="INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</dt>
           <dd>
 The [=verification method=] in a [=controlled identifier document=] was malformed. See Section
 [[[#retrieve-verification-method]]].
           </dd>
-          <dt id="INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD">INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD (-25)</dt>
+          <dt id="INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD">INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD</dt>
           <dd>
 The [=verification method=] in a [=controlled identifier document=] was not
 associated using the expected [=verification relationship=] as expressed in

--- a/index.html
+++ b/index.html
@@ -2708,7 +2708,7 @@ The `title` value SHOULD provide a short but specific human-readable string for
 the error.
           </li>
           <li>
-The `detail` value  MUST be present and it SHOULD provide a longer human-readable string for the error.
+The `detail` value SHOULD provide a longer human-readable string for the error.
           </li>
         </ul>
 

--- a/index.html
+++ b/index.html
@@ -2704,7 +2704,7 @@ The `type` value of the error object MUST be a URL that starts with the value
 below.
           </li>
           <li>
-The `title` value MUST be present and it SHOULD provide a short but specific human-readable string for
+The `title` value SHOULD provide a short but specific human-readable string for
 the error.
           </li>
           <li>


### PR DESCRIPTION
This is the sister PR to https://github.com/w3c/vc-data-integrity/pull/327 removing the numerical codes from the error entries. See https://github.com/w3c/vc-data-integrity/pull/327 for further description of the changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/cid/pull/140.html" title="Last updated on Jan 20, 2025, 7:16 AM UTC (2b878d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cid/140/3ca9cc5...2b878d5.html" title="Last updated on Jan 20, 2025, 7:16 AM UTC (2b878d5)">Diff</a>