### PR TITLE
Add fragment processing algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -2690,15 +2690,14 @@ relationships exist as described earlier in this section.
         </p>
 
         <p class="note" title="Fragment identifier processing">
-The fragment identifier processing rules for retrieving [=verification methods=]
-are dependent on the media type of a [=controlled identifier document=]. While
-the algorithm in this section attempts to defer to the media type of the
-corresponding [=controlled identifier document=] (such as `application/did`),
-and while Section [[[#fragment-resolution]]] defines how to resolve fragment
+The fragment identifier processing rules when retrieving [=verification methods=]
+depend on the media type of a [=controlled identifier document=]. While the
+algorithm in this section attempts to defer to the media type of the
+corresponding [=controlled identifier document=] (such as `application/did`), and
+while Section [[[#fragment-resolution]]] defines how to resolve fragment
 identifiers according to the `application/cid` media type, implementers are
-advised that other fragment processing rules might exist that perform fragment
-processing in alternative ways that might result in different outcomes based on
-the media type.
+advised that a [=controlled identifier document=] of another media type might
+require different fragment processing rules that might produce different results.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -2244,11 +2244,11 @@ the Multihash value itself.
 
       <p>
 This section defines algorithms used by this specification including
-instructions on how to base-encode and base-decode values, safely retrieve
-verification methods, retrieve document fragments, and produce processing error
-descriptions over HTTP channels. Alternatives to the algorithms provided in this
-section MAY be used as long as the outputs of the alternative algorithm remain
-the same.
+instructions on the following: how to base-encode and base-decode values; 
+how to safely retrieve verification methods; how to retrieve document
+fragments; and how to produce descriptions of processing errors over HTTP
+channels. Alternatives to the algorithms provided in this section MAY be
+used as long as the outputs of the alternative algorithm remain the same.
       </p>
 
       <section class="normative">

--- a/index.html
+++ b/index.html
@@ -2245,7 +2245,10 @@ the Multihash value itself.
       <p>
 This section defines algorithms used by this specification including
 instructions on how to base-encode and base-decode values, safely retrieve
-verification methods, and produce processing errors over HTTP channels.
+verification methods, retrieve document fragments, and produce processing error
+descriptions over HTTP channels. Alternatives to the algorithms provided in this
+section MAY be used as long as the outputs of the alternative algorithm remain
+the same.
       </p>
 
       <section class="normative">
@@ -2258,8 +2261,6 @@ particular base alphabet, such as base-64-url-no-pad or base-58-btc. The
 required inputs are the <var>bytes</var>, <var>targetBase</var>, and
 <var>baseAlphabet</var>. The output is a string that contains the base-encoded
 value. All mathematical operations MUST be performed using integer arithmetic.
-Alternatives to the algorithm provided below MAY be used as long as the
-outputs of the alternative algorithm remain the same.
         </p>
 
         <ol class="algorithm">
@@ -2404,8 +2405,7 @@ uses a particular base alphabet, such as base-64-url-no-pad or base-58-btc. The
 required inputs are the <var>sourceEncoding</var>, <var>sourceBase</var>, and
 <var>baseAlphabet</var>. The output is an array of bytes that contains the
 base-decoded value. All mathematical operations MUST be performed using integer
-arithmetic. Alternatives to the algorithm provided below MAY be used as long as
-the outputs of the alternative algorithm remain the same.
+arithmetic.
         </p>
 
         <ol class="algorithm">
@@ -2687,6 +2687,18 @@ In the example above, the algorithm described in this section will use the
 identifier=]. The algorithm will then confirm that the [=verification method=]
 exists in the external [=controlled identifier document=] and that the appropriate
 relationships exist as described earlier in this section.
+        </p>
+
+        <p class="note" title="Fragment identifier processing">
+The fragment identifier processing rules for retrieving [=verification methods=]
+are dependent on the media type of a [=controlled identifier document=]. While
+the algorithm in this section attempts to defer to the media type of the
+corresponding [=controlled identifier document=] (such as `application/did`),
+and while Section [[[#fragment-resolution]]] defines how to resolve fragment
+identifiers according to the `application/cid` media type, implementers are
+advised that other fragment processing rules might exist that perform fragment
+processing in alternative ways that might result in different outcomes based on
+the media type.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -1282,7 +1282,7 @@ resource with which it is associated.
 Note, however, that for [=verification methods=], it is only
 an assertion made by the `controller` of the [=controlled identifier document=],
 and this assertion is not necessarily true, i.e., it may be false.
-To ensure that a [=verification method=] 
+To ensure that a [=verification method=]
 is bound to a particular [=controller=],
 one must go from the expression of the [=verification method=]
 to its [=controlled-identifier-document=],
@@ -2691,6 +2691,51 @@ relationships exist as described earlier in this section.
 
       </section>
 
+
+      <section class="normative">
+        <h2>Fragment Resolution</h2>
+
+        <p>
+The following algorithm specifies how to retrieve the portion of a document that
+contains a given fragment identifier. The required inputs are a [=controlled
+identifier document=] ([=map=] <var>document</var>) and a fragment identifier
+([=string=] <var>fragmentIdentifier</var>). The output is a [=map=] containing
+the document fragment.
+        </p>
+
+        <ol class="algorithm">
+          <li>
+Let <var>documentFragment</var> be `null`.
+          </li>
+          <li>
+Let <var>canonicalDocumentUrl</var> be the value of
+<var>document</var>.<var>id</var>.
+          </li>
+          <li>
+Let <var>fullyQualifiedFragment</var> be the value of
+<var>canonicalDocumentUrl</var> with <var>fragmentIdentifier</var> appended to
+it.
+          </li>
+          <li>
+Recursively process every [=map=] in <var>document</var> checking to see if
+it has an `id` value that is equal to <var>fullyQualifiedFragment</var> or
+<var>fragmentIdentifier</var>. If a match is found, set
+<var>documentFragment</var> to the matched [=map=] and stop recursively
+processing.
+          </li>
+          <li>
+Return <var>documentFragment</var>.
+          </li>
+        </ol>
+
+        <p class="note" title="Multiple fragments with the same value">
+While it is possible to express a document that contains multiple fragments that
+use the same identifier, due to interoperability concerns, doing so is to be
+avoided and the behaviour is not defined.
+        </p>
+
+      </section>
+
       <section class="normative">
         <h3>Processing Errors</h3>
 
@@ -3753,11 +3798,17 @@ format.
           </tr>
           <tr>
             <td>Subtype name: </td>
-            <td>controller</td>
+            <td>cid</td>
           </tr>
           <tr>
             <td>Required parameters: </td>
             <td>None</td>
+          </tr>
+          <tr>
+            <td>Fragment identifier considerations:</td>
+            <td>
+As defined in Section [[[#fragment-resolution]]] in the [[[CID]]] specification.
+            </td>
           </tr>
           <tr>
             <td>Encoding considerations: </td>
@@ -3770,7 +3821,10 @@ subject to the same encoding considerations specified in Section 11 of
           </tr>
           <tr>
             <td>Security considerations: </td>
-            <td>As defined in the [[[CID]]].</td>
+            <td>
+As defined in Section [[[#security-considerations]]] in the [[[CID]]]
+specification.
+            </td>
           </tr>
           <tr>
             <td>Contact: </td>


### PR DESCRIPTION
This PR is an attempt to address issue #133 and #137 by defining the fragment resolution algorithm for `application/cid`, updating the media type registration, allowing alternate algorithms as long as the outcome is the same, and noting that fragment processing is media type dependent.

/cc @jyasskin


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/cid/pull/142.html" title="Last updated on Jan 20, 2025, 6:27 PM UTC (c081f79)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cid/142/901c2a2...c081f79.html" title="Last updated on Jan 20, 2025, 6:27 PM UTC (c081f79)">Diff</a>