### PR TITLE
Update echidna yml

### DIFF
--- a/.github/workflows/echidna.yml
+++ b/.github/workflows/echidna.yml
@@ -17,5 +17,5 @@ jobs:
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}
           W3C_WG_DECISION_URL: https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-04-12-vcwg#resolution1
           W3C_BUILD_OVERRIDE: |
-             shortName: controller-document
-             specStatus: WD 
+             shortName: cid-1.0
+             specStatus: CRD 


### PR DESCRIPTION
- updated short name (to `cid-1.0`)
- spec status is now `CRD`

I have also created a new W3C_TR_TOKEN for the new short name and updated the repository.